### PR TITLE
Cloth support 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -594,7 +594,7 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rdm4-bin"
-version = "0.9.0-alpha.1"
+version = "0.10.0-cloth-taub"
 dependencies = [
  "clap",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rdm4-bin"
-version = "0.10.0-cloth-taub
+version = "0.10.0-cloth-taub"
 publish = false
 authors = ["lukts30 <llukas21307@gmail.com>"]
 edition = "2021"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rdm4-bin"
-version = "0.9.0-alpha.1"
+version = "0.10.0-cloth-taub
 publish = false
 authors = ["lukts30 <llukas21307@gmail.com>"]
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ OPTIONS:
 GLTF TO RDM OPTIONS:
     -g, --gltf <VertexFormat>
             VertexFormat for output rdm: P4h_N4b_G4b_B4b_T2h | P4h_N4b_G4b_B4b_T2h_I4b |
-            P4h_N4b_G4b_B4b_T2h_I4b_W4b
+            P4h_N4b_G4b_B4b_T2h_I4b_W4b | P3f_N3f_G3f_B3f_T2f_C4b
 
         --gltf-mesh-index <GLTF_MESH_INDEX>
             glTF mesh index to convert to rdm [default: 0]
@@ -84,11 +84,8 @@ Can be shortened to:
 $ ./rdm4-bin.exe -i rdm/container_ship_tycoons_lod1.rdm -sam anim/container_ship_tycoons_idle01.rdm
 ```
 
-
 ## Example usage glTF 2.0 🠚 rdm
-**Flag --gltf or the alias -g must be used !**
-- *Possible values are: P4h_N4b_G4b_B4b_T2h | P4h_N4b_G4b_B4b_T2h_I4b | P4h_N4b_G4b_B4b_T2h_I4b_W4b*
-- If you are not converting an animated glTF use `-g=P4h_N4b_G4b_B4b_T2h`!
+**Flag --gltf or the alias -g must be used! See the section on vertex formats below**
 - **Note**: the example given here uses `-g=P4h_N4b_G4b_B4b_T2h_I4b_W4b` and `-sa` since it converts an animated glTF to rdm with anim files.
 <details>
 <summary>Click to expand</summary>
@@ -369,6 +366,20 @@ $ ./rdm4-bin.exe -g=P4h_N4b_G4b_B4b_T2h_I4b_W4b -i untitled.gltf -sa
 ```
 
 </details>
+
+## Setting Vertex Formats for glTF 2.0 🠚 rdm
+
+**-g sets your vertex format
+
+### `P4h_N4b_G4b_B4b_T2h`: Vertex Format for standard meshes
+### `P4h_N4b_G4b_B4b_T2h_I4b`: Vertex Format with unweighted Joints
+- This needs at least Joint Data exported to the gltf.
+### `P4h_N4b_G4b_B4b_T2h_I4b_W4b`: Vertex Format with weighted Joints, i.e. Portraits
+- This needs Joint and Weight Data exported to the gltf.
+### `P3f_N3f_G3f_B3f_T2f_C4b`: Cloth
+- Needs vertex colors in the export. If you don't have an idea how to create them in blender, refer to [this video](https://www.youtube.com/watch?v=8mNk6r_bwxI)
+
+> TLDR, if you just want a standard model, use `-g=P4h_N4b_G4b_B4b_T2h`!
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -378,6 +378,10 @@ $ ./rdm4-bin.exe -g=P4h_N4b_G4b_B4b_T2h_I4b_W4b -i untitled.gltf -sa
 - This needs Joint and Weight Data exported to the gltf.
 ### `P3f_N3f_G3f_B3f_T2f_C4b`: Cloth
 - Needs vertex colors in the export. If you don't have an idea how to create them in blender, refer to [this video](https://www.youtube.com/watch?v=8mNk6r_bwxI)
+### `P4h_T2h_C4b`: Decal Detail 
+- Needs vertex colors in the export.
+- Anno uses the vertex color for deviation in luminosity. 
+- Use gray=0.5 as your standard color, then paint darker and brighter spots. 
 
 > TLDR, if you just want a standard model, use `-g=P4h_N4b_G4b_B4b_T2h`!
 

--- a/rdm4lib/src/gltf_export.rs
+++ b/rdm4lib/src/gltf_export.rs
@@ -357,7 +357,7 @@ impl RdGltfBuilder {
         let n = self
             .rdm
             .vertex
-            .find_component_offsets(UniqueIdentifier::I4b)
+            .find_component_offsets(UniqueIdentifier::Joint)
             .count();
         let mut ibuffers = Vec::with_capacity(n);
         let mut wbuffers = Vec::with_capacity(n);

--- a/rdm4lib/src/gltf_reader.rs
+++ b/rdm4lib/src/gltf_reader.rs
@@ -564,6 +564,9 @@ impl<'a> ImportedGltf {
                 TargetVertexFormat::P3f_N3f_G3f_B3f_T2f_C4b => {
                     crate::vertex::p3f_n3f_g3f_b3f_t2f_c4b().to_vec()
                 }
+                TargetVertexFormat::P4h_T2h_C4b => {                    
+                    crate::vertex::p4h_t2h_c4c().to_vec()
+                },
             };
             let vertsize = ident.iter().map(|x| x.get_size()).sum();
 
@@ -773,9 +776,18 @@ impl<'a> ImportedGltf {
                             match color {
                                 //intentional use of w4b as we just treat weight as vertexcolor
                                 Some(x) => verts_vec.put_vertex_data(&c4b(x)),
-                                None => error!("No weights left in gltf! P3f_N3f_G3f_B3f_T2f_C4b requires weights to be present!")
+                                None => error!("No Colors left in gltf! P3f_N3f_G3f_B3f_T2f_C4b requires weights to be present!")
                             } 
                         }
+                        TargetVertexFormat::P4h_T2h_C4b => {                            
+                            verts_vec.put_vertex_data(&p4h(vec_position));
+                            verts_vec.put_vertex_data(&t2h(tex));
+                            match color {
+                                //intentional use of w4b as we just treat weight as vertexcolor
+                                Some(x) => verts_vec.put_vertex_data(&c4c(x)),
+                                None => error!("No Colors left in gltf! P4h_T2h_C4b requires weights to be present!")
+                            } 
+                        },
                     }
 
                     count -= 1;

--- a/rdm4lib/src/gltf_reader_vertex.rs
+++ b/rdm4lib/src/gltf_reader_vertex.rs
@@ -14,6 +14,14 @@ impl<const I: u32, const N: usize> PutVertex<u8, I, N> for BytesMut {
     }
 }
 
+impl<const I: u32, const N: usize> PutVertex<i8, I, N> for BytesMut {
+    fn put_vertex_data(&mut self, input: &AnnoData<i8, I, N>) {
+        for e in input.data.iter() {
+            self.put_i8(*e);
+        }
+    }
+}
+
 impl<const I: u32, const N: usize> PutVertex<f16, I, N> for BytesMut {
     fn put_vertex_data(&mut self, input: &AnnoData<f16, I, N>) {
         for e in input.data.iter() {

--- a/rdm4lib/src/gltf_reader_vertex.rs
+++ b/rdm4lib/src/gltf_reader_vertex.rs
@@ -1,3 +1,4 @@
+use byteorder::LittleEndian;
 use bytes::{BufMut, BytesMut};
 use half::f16;
 
@@ -17,6 +18,14 @@ impl<const I: u32, const N: usize> PutVertex<f16, I, N> for BytesMut {
     fn put_vertex_data(&mut self, input: &AnnoData<f16, I, N>) {
         for e in input.data.iter() {
             self.put_u16_le(e.to_bits());
+        }
+    }
+}
+
+impl<const I: u32, const N: usize> PutVertex<f32, I, N> for BytesMut {
+    fn put_vertex_data(&mut self, input: &AnnoData<f32, I, N>) {
+        for e in input.data.iter() {
+            self.put_f32_le(*e);
         }
     }
 }

--- a/rdm4lib/src/lib.rs
+++ b/rdm4lib/src/lib.rs
@@ -23,6 +23,7 @@ pub mod gltf_reader_vertex;
 pub mod rdm_anim;
 pub mod rdm_material;
 pub mod vertex;
+pub mod vertex_transform;
 use crate::rdm_anim::RdAnim;
 use rdm_material::RdMaterial;
 

--- a/rdm4lib/src/vertex.rs
+++ b/rdm4lib/src/vertex.rs
@@ -57,7 +57,7 @@ impl UniqueIdentifier {
             0x3 => UniqueIdentifier::Bitangent,
             0x4 => UniqueIdentifier::Texcoord,
             0x5 => UniqueIdentifier::Color,
-            0x7 => UniqueIdentifier::I4b,
+            0x7 => UniqueIdentifier::Joint,
             0x6 => UniqueIdentifier::Weight,
             _ => UniqueIdentifier::Invalid,
         }
@@ -120,7 +120,7 @@ pub(crate) type B4b = AnnoData<u8, { UniqueIdentifier::Bitangent as u32 }, 4>;
 pub(crate) type T2f = AnnoData<f32, { UniqueIdentifier::Texcoord as u32 }, 2>;
 pub(crate) type T2h = AnnoData<f16, { UniqueIdentifier::Texcoord as u32 }, 2>;
 
-pub(crate) type I4b = AnnoData<u8, { UniqueIdentifier::I4b as u32 }, 4>;
+pub(crate) type I4b = AnnoData<u8, { UniqueIdentifier::Joint as u32 }, 4>;
 pub(crate) type W4b = AnnoData<u8, { UniqueIdentifier::Weight as u32 }, 4>;
 
 impl<T: Default + Copy, const I: u32, const N: usize> Default for AnnoData<T, I, N> {
@@ -498,7 +498,7 @@ impl VertexIdentifier {
 
     pub const fn i4b() -> Self {
         VertexIdentifier {
-            uniq: UniqueIdentifier::I4b,
+            uniq: UniqueIdentifier::Joint,
             unit_size: IdentifierSize::U32,
             interpretation: 0x0,
             count: 1,

--- a/rdm4lib/src/vertex.rs
+++ b/rdm4lib/src/vertex.rs
@@ -123,6 +123,10 @@ pub(crate) type T2h = AnnoData<f16, { UniqueIdentifier::Texcoord as u32 }, 2>;
 pub(crate) type I4b = AnnoData<u8, { UniqueIdentifier::Joint as u32 }, 4>;
 pub(crate) type W4b = AnnoData<u8, { UniqueIdentifier::Weight as u32 }, 4>;
 
+
+pub(crate) type C4b = AnnoData<u8, { UniqueIdentifier::Color as u32 }, 4>;
+pub(crate) type C4c = AnnoData<u8, { UniqueIdentifier::Color as u32 }, 4>;
+
 impl<T: Default + Copy, const I: u32, const N: usize> Default for AnnoData<T, I, N> {
     fn default() -> Self {
         Self {
@@ -604,7 +608,7 @@ impl FromStr for TargetVertexFormat {
 pub trait VertexFormatProperties {
     fn has_weights(vertex_format: &TargetVertexFormat) -> bool;
     fn has_joints(vertex_format: &TargetVertexFormat) -> bool;
-    fn has_color(vertex_format: &TargetVertexFormat) -> bool;
+    fn has_colors(vertex_format: &TargetVertexFormat) -> bool;
 
     //this is for later when we want to implementmultiple indices and weights 
     fn weight_count() -> u8; 
@@ -614,15 +618,28 @@ pub trait VertexFormatProperties {
 
 impl VertexFormatProperties for TargetVertexFormat {
     fn has_weights(vertex_format: &TargetVertexFormat) -> bool {
-        false
+        match vertex_format {
+            TargetVertexFormat::P4h_N4b_G4b_B4b_T2h => false,
+            TargetVertexFormat::P4h_N4b_G4b_B4b_T2h_I4b => false,
+            TargetVertexFormat::P4h_N4b_G4b_B4b_T2h_I4b_W4b => true,
+            TargetVertexFormat::P3f_N3f_G3f_B3f_T2f_C4b => true,
+        }
     }
 
     fn has_joints(vertex_format: &TargetVertexFormat) -> bool {
-        false
+        match vertex_format {
+            TargetVertexFormat::P4h_N4b_G4b_B4b_T2h => false,
+            TargetVertexFormat::P4h_N4b_G4b_B4b_T2h_I4b => true,
+            TargetVertexFormat::P4h_N4b_G4b_B4b_T2h_I4b_W4b => true,
+            TargetVertexFormat::P3f_N3f_G3f_B3f_T2f_C4b => false,
+        }
     }
 
-    fn has_color(vertex_format: &TargetVertexFormat) -> bool {
-        false
+    fn has_colors(vertex_format: &TargetVertexFormat) -> bool {
+        match vertex_format {
+            TargetVertexFormat::P3f_N3f_G3f_B3f_T2f_C4b => true,
+            _ => false
+        }
     }
 
     fn weight_count() -> u8 {

--- a/rdm4lib/src/vertex.rs
+++ b/rdm4lib/src/vertex.rs
@@ -125,7 +125,7 @@ pub(crate) type W4b = AnnoData<u8, { UniqueIdentifier::Weight as u32 }, 4>;
 
 
 pub(crate) type C4b = AnnoData<u8, { UniqueIdentifier::Color as u32 }, 4>;
-pub(crate) type C4c = AnnoData<u8, { UniqueIdentifier::Color as u32 }, 4>;
+pub(crate) type C4c = AnnoData<i8, { UniqueIdentifier::Color as u32 }, 4>;
 
 impl<T: Default + Copy, const I: u32, const N: usize> Default for AnnoData<T, I, N> {
     fn default() -> Self {
@@ -572,16 +572,13 @@ pub const fn p3f_n3f_g3f_b3f_t2f_c4b() -> [VertexIdentifier; 6] {
     ]
 }
 
-/* 
-pub const fn p4h_t2h_c4c() -> [VertexIdentifier; 3] 
-{
+pub const fn p4h_t2h_c4c() -> [VertexIdentifier; 3] {
     [
         VertexIdentifier::p4h(),
         VertexIdentifier::t2h(),
         VertexIdentifier::c4b(),
     ]
 }
-*/
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 #[allow(non_camel_case_types)]
@@ -589,7 +586,8 @@ pub enum TargetVertexFormat {
     P4h_N4b_G4b_B4b_T2h,
     P4h_N4b_G4b_B4b_T2h_I4b,
     P4h_N4b_G4b_B4b_T2h_I4b_W4b,
-    P3f_N3f_G3f_B3f_T2f_C4b
+    P3f_N3f_G3f_B3f_T2f_C4b,
+    P4h_T2h_C4b
 }
 impl FromStr for TargetVertexFormat {
     type Err = String;
@@ -600,6 +598,7 @@ impl FromStr for TargetVertexFormat {
             "P4h_N4b_G4b_B4b_T2h_I4b" => Ok(TargetVertexFormat::P4h_N4b_G4b_B4b_T2h_I4b),
             "P4h_N4b_G4b_B4b_T2h_I4b_W4b" => Ok(TargetVertexFormat::P4h_N4b_G4b_B4b_T2h_I4b_W4b),
             "P3f_N3f_G3f_B3f_T2f_C4b" => Ok(TargetVertexFormat::P3f_N3f_G3f_B3f_T2f_C4b),
+            "P4h_T2h_C4b" => Ok(TargetVertexFormat::P4h_T2h_C4b),
             _ => Err(format!("Invalid value for VertexFormat: {}", input)),
         }
     }
@@ -623,6 +622,7 @@ impl VertexFormatProperties for TargetVertexFormat {
             TargetVertexFormat::P4h_N4b_G4b_B4b_T2h_I4b => false,
             TargetVertexFormat::P4h_N4b_G4b_B4b_T2h_I4b_W4b => true,
             TargetVertexFormat::P3f_N3f_G3f_B3f_T2f_C4b => true,
+            TargetVertexFormat::P4h_T2h_C4b => false,
         }
     }
 
@@ -631,13 +631,15 @@ impl VertexFormatProperties for TargetVertexFormat {
             TargetVertexFormat::P4h_N4b_G4b_B4b_T2h => false,
             TargetVertexFormat::P4h_N4b_G4b_B4b_T2h_I4b => true,
             TargetVertexFormat::P4h_N4b_G4b_B4b_T2h_I4b_W4b => true,
-            TargetVertexFormat::P3f_N3f_G3f_B3f_T2f_C4b => false,
+            TargetVertexFormat::P3f_N3f_G3f_B3f_T2f_C4b => 
+            false,TargetVertexFormat::P4h_T2h_C4b => false,
         }
     }
 
     fn has_colors(vertex_format: &TargetVertexFormat) -> bool {
         match vertex_format {
             TargetVertexFormat::P3f_N3f_G3f_B3f_T2f_C4b => true,
+            TargetVertexFormat::P4h_T2h_C4b => true,
             _ => false
         }
     }

--- a/rdm4lib/src/vertex.rs
+++ b/rdm4lib/src/vertex.rs
@@ -526,6 +526,23 @@ impl VertexIdentifier {
             count: 1,
         }
     }
+    
+    pub const fn c4b_interpret2() -> Self {
+        VertexIdentifier {
+            uniq: UniqueIdentifier::Color,
+            unit_size: IdentifierSize::U32,
+            interpretation: 0x2,
+            count: 1,
+        }
+    }
+    pub const fn c4b_interpret6() -> Self {
+        VertexIdentifier {
+            uniq: UniqueIdentifier::Color,
+            unit_size: IdentifierSize::U32,
+            interpretation: 0x6,
+            count: 1,
+        }
+    }
 }
 
 pub const fn p4h_n4b_g4b_b4b_t2h_i4b() -> [VertexIdentifier; 6] {
@@ -561,6 +578,19 @@ pub const fn p4h_n4b_g4b_b4b_t2h() -> [VertexIdentifier; 5] {
     ]
 }
 
+pub const fn p4h_n4b_g4b_b4b_t2h_c4b_c4b() -> [VertexIdentifier; 7] {
+    [
+        VertexIdentifier::p4h(),
+        VertexIdentifier::n4b(),
+        VertexIdentifier::g4b(),
+        VertexIdentifier::b4b(),
+        VertexIdentifier::t2h(),
+        VertexIdentifier::c4b_interpret2(),
+        VertexIdentifier::c4b_interpret6()
+    ]
+}
+
+
 pub const fn p3f_n3f_g3f_b3f_t2f_c4b() -> [VertexIdentifier; 6] {
     [
         VertexIdentifier::p3f(),
@@ -587,6 +617,7 @@ pub enum TargetVertexFormat {
     P4h_N4b_G4b_B4b_T2h_I4b,
     P4h_N4b_G4b_B4b_T2h_I4b_W4b,
     P3f_N3f_G3f_B3f_T2f_C4b,
+    P4h_N4b_G4b_B4b_T2h_C4b_C4b,
     P4h_T2h_C4b
 }
 impl FromStr for TargetVertexFormat {
@@ -598,6 +629,7 @@ impl FromStr for TargetVertexFormat {
             "P4h_N4b_G4b_B4b_T2h_I4b" => Ok(TargetVertexFormat::P4h_N4b_G4b_B4b_T2h_I4b),
             "P4h_N4b_G4b_B4b_T2h_I4b_W4b" => Ok(TargetVertexFormat::P4h_N4b_G4b_B4b_T2h_I4b_W4b),
             "P3f_N3f_G3f_B3f_T2f_C4b" => Ok(TargetVertexFormat::P3f_N3f_G3f_B3f_T2f_C4b),
+            "P4h_N4b_G4b_B4b_T2h_C4b_C4b" => Ok(TargetVertexFormat::P4h_N4b_G4b_B4b_T2h_C4b_C4b),
             "P4h_T2h_C4b" => Ok(TargetVertexFormat::P4h_T2h_C4b),
             _ => Err(format!("Invalid value for VertexFormat: {}", input)),
         }
@@ -610,9 +642,9 @@ pub trait VertexFormatProperties {
     fn has_colors(vertex_format: &TargetVertexFormat) -> bool;
 
     //this is for later when we want to implementmultiple indices and weights 
-    fn weight_count() -> u8; 
-    fn joint_count() -> u8;
-    fn color_count() -> u8;  
+    fn weight_count(vertex_format: &TargetVertexFormat) -> u32; 
+    fn joint_count(vertex_format: &TargetVertexFormat) -> u32;
+    fn color_count(vertex_format: &TargetVertexFormat) -> u32;  
 }
 
 impl VertexFormatProperties for TargetVertexFormat {
@@ -623,6 +655,7 @@ impl VertexFormatProperties for TargetVertexFormat {
             TargetVertexFormat::P4h_N4b_G4b_B4b_T2h_I4b_W4b => true,
             TargetVertexFormat::P3f_N3f_G3f_B3f_T2f_C4b => true,
             TargetVertexFormat::P4h_T2h_C4b => false,
+            TargetVertexFormat::P4h_N4b_G4b_B4b_T2h_C4b_C4b => false,
         }
     }
 
@@ -633,6 +666,7 @@ impl VertexFormatProperties for TargetVertexFormat {
             TargetVertexFormat::P4h_N4b_G4b_B4b_T2h_I4b_W4b => true,
             TargetVertexFormat::P3f_N3f_G3f_B3f_T2f_C4b => 
             false,TargetVertexFormat::P4h_T2h_C4b => false,
+            TargetVertexFormat::P4h_N4b_G4b_B4b_T2h_C4b_C4b => false,
         }
     }
 
@@ -640,20 +674,36 @@ impl VertexFormatProperties for TargetVertexFormat {
         match vertex_format {
             TargetVertexFormat::P3f_N3f_G3f_B3f_T2f_C4b => true,
             TargetVertexFormat::P4h_T2h_C4b => true,
+            TargetVertexFormat::P4h_N4b_G4b_B4b_T2h_C4b_C4b => true,
             _ => false
         }
     }
 
-    fn weight_count() -> u8 {
-        1
+    fn weight_count(vertex_format: &TargetVertexFormat) -> u32 {
+        match vertex_format
+        {
+            TargetVertexFormat::P4h_N4b_G4b_B4b_T2h_I4b_W4b => 1,
+            _ => 0
+        }
     }
 
-    fn joint_count() -> u8 {
-        1
+    fn joint_count(vertex_format: &TargetVertexFormat) -> u32 {
+        match vertex_format
+        {
+            TargetVertexFormat::P4h_N4b_G4b_B4b_T2h_I4b_W4b => 1,
+            TargetVertexFormat::P4h_N4b_G4b_B4b_T2h_I4b => 1,
+            _ => 0
+        }
     }
 
-    fn color_count() -> u8 {
-        1
+    fn color_count(vertex_format: &TargetVertexFormat)-> u32 {
+        match vertex_format
+        {
+            TargetVertexFormat::P3f_N3f_G3f_B3f_T2f_C4b => 1,
+            TargetVertexFormat::P4h_T2h_C4b => 1,
+            TargetVertexFormat::P4h_N4b_G4b_B4b_T2h_C4b_C4b => 2,
+            _ => 0
+        }
     }
 }
 

--- a/rdm4lib/src/vertex_transform.rs
+++ b/rdm4lib/src/vertex_transform.rs
@@ -187,3 +187,9 @@ pub fn w4b(weight: [f32; 4]) -> W4b {
         ],
     }
 }
+
+pub fn c4b(color: [u8; 4]) -> C4b {
+    C4b {
+        data: color,
+    }
+}

--- a/rdm4lib/src/vertex_transform.rs
+++ b/rdm4lib/src/vertex_transform.rs
@@ -1,0 +1,189 @@
+use half::f16;
+use nalgebra::Vector3;
+use crate::vertex::*;
+use crate::vertex::W4b;
+use nalgebra::*;
+
+pub struct TransformContext {
+    pub(crate) base: Matrix<f32, Const<4>, Const<4>, ArrayStorage<f32, 4, 4>>,
+    pub(crate) transpose_inv_transform_mat3 : Matrix<f32, Const<3>, Const<3>, ArrayStorage<f32, 3, 3>>,
+}
+
+impl TransformContext {    
+    pub fn transform_position(&mut self, position : [f32; 3]) -> Point<f32, 3> {
+        let vertex = Point3::new(position[0], position[1], position[2]);
+        return self.base.transform_point(&vertex)
+    }
+
+    pub fn transform_tangent(&mut self, tangents: [f32; 4]) -> Vector3<f32> {
+        let tangv = Vector3::new(tangents[0], tangents[1], tangents[2]);
+        let transformed_tangents = self.transpose_inv_transform_mat3 * tangv;
+
+        let mut tx = transformed_tangents[0];
+        let mut ty = transformed_tangents[1];
+        let mut tz = transformed_tangents[2];
+        let tlen = -1.0;
+        tx /= tlen;
+        ty /= tlen;
+        tz /= tlen;
+
+        return Vector3::new(tx, ty, tz); 
+    }
+
+    pub fn transform_normal(&mut self, normal : [f32; 3]) -> Vector3<f32>{
+        let normv: Vector3<f32> = Vector3::new(normal[0], normal[1], normal[2]);
+        let transformed_normal: Vector3<f32> = self.transpose_inv_transform_mat3 * normv;
+
+        let mut nx = transformed_normal[0];
+        let mut ny = transformed_normal[1];
+        let mut nz = transformed_normal[2];
+
+        let len = ((nx * nx) + (ny * ny) + (nz * nz)).sqrt();
+
+        nx /= len;
+        ny /= len;
+        nz /= len;
+
+        return Vector3::new(nx, ny, nz)
+    }
+}
+
+
+
+// # Position #
+pub fn p4h(position: Point<f32, 3>) -> P4h {
+    P4h {
+        data: [
+            f16::from_f32(1.0 * position[0]),
+            f16::from_f32(1.0 * position[1]),
+            f16::from_f32(1.0 * position[2]),
+            f16::from_f32(0.0),
+        ],  
+    }
+}
+
+pub fn p3f(position: Point<f32, 3>) -> P3f {
+    P3f {
+        data: [
+            1.0 * position[0],
+            1.0 * position[1],
+            1.0 * position[2]
+        ]
+    }
+}
+
+
+// # Normals #
+
+pub fn n4b(vec_normal: Vector3<f32>) -> N4b {
+    N4b {
+        data: [
+            (((vec_normal.x + 1.0) / 2.0) * 255.0).round() as u8,
+            (((vec_normal.y + 1.0) / 2.0) * 255.0).round() as u8,
+            (((vec_normal.z + 1.0) / 2.0) * 255.0).round() as u8,
+            0,
+        ],
+    }
+}
+
+pub fn n3f(vec_normal: Vector3<f32>)  -> N3f {
+    N3f {
+        data: [
+            vec_normal.x,
+            vec_normal.y,
+            vec_normal.z
+        ]
+    }
+}
+
+// # Tangents #
+pub fn g4b(vec_tangent: Vector3<f32>) -> G4b {
+    G4b {
+        data: [
+            (((vec_tangent.x + 1.0) / 2.0) * 255.0).round() as u8,
+            (((vec_tangent.y + 1.0) / 2.0) * 255.0).round() as u8,
+            (((vec_tangent.z + 1.0) / 2.0) * 255.0).round() as u8,
+            0,
+        ]
+    }
+}
+
+pub fn g3f(vec_tangent: Vector3<f32>) -> G3f {
+    G3f {
+        data: [
+            vec_tangent.x,
+            vec_tangent.y,
+            vec_tangent.z
+        ]
+    }
+}
+
+// # Bitangents #
+pub fn b4b(vec_tangent: Vector3<f32>, vec_normal: Vector3<f32>, tangent_w: f32) -> B4b {
+    debug!("normal.dot(&tangent): {}", vec_normal.dot(&vec_tangent));
+    let b: Matrix3x1<f32> = (vec_normal.cross(&vec_tangent)) * (tangent_w);
+
+    B4b {
+        data: [
+            (((b.x + 1.0) / 2.0) * 255.0).round() as u8,
+            (((b.y + 1.0) / 2.0) * 255.0).round() as u8,
+            (((b.z + 1.0) / 2.0) * 255.0).round() as u8,
+            0,
+        ],
+    }
+}
+
+pub fn b3f(vec_tangent: Vector3<f32>, vec_normal: Vector3<f32>, tangent_w: f32) -> B3f {
+    debug!("normal.dot(&tangent): {}", vec_normal.dot(&vec_tangent));
+    let b: Matrix3x1<f32> = (vec_normal.cross(&vec_tangent)) * (tangent_w);
+
+    B3f {
+        data: [
+            b.x,
+            b.y,
+            b.z
+        ]
+    }
+}
+
+// # UV # 
+pub fn t2h(uv : [f32; 2]) -> T2h {
+    T2h {
+        data: [
+            f16::from_f32(uv[0]), f16::from_f32(uv[1])
+        ]
+    }
+}
+
+pub fn t2f(uv: [f32; 2]) -> T2f {
+    T2f {
+        data: [
+            uv[0],
+            uv[1]
+        ]
+    }
+}
+
+// # Joints # 
+pub fn i4b(joint: [u16; 4]) -> I4b {
+    I4b {
+        data: [
+            joint[0] as u8,
+            joint[1] as u8,
+            joint[2] as u8,
+            joint[3] as u8,
+        ],
+    }
+}
+
+// # Weights # 
+pub fn w4b(weight: [f32; 4]) -> W4b {
+    W4b {
+        data: [
+            (weight[0] * 255.0).round() as u8,
+            (weight[1] * 255.0).round() as u8,
+            (weight[2] * 255.0).round() as u8,
+            (weight[3] * 255.0).round() as u8,
+        ],
+    }
+}

--- a/rdm4lib/src/vertex_transform.rs
+++ b/rdm4lib/src/vertex_transform.rs
@@ -193,3 +193,14 @@ pub fn c4b(color: [u8; 4]) -> C4b {
         data: color,
     }
 }
+
+pub fn c4c(color: [u8; 4]) -> C4c {
+    C4c {
+        data: [
+            (color[0] as i16 - 128) as i8,
+            (color[1] as i16 - 128) as i8,
+            (color[2] as i16 - 128) as i8,
+            (color[3] as i16 - 128) as i8,
+        ],
+    }
+}


### PR DESCRIPTION
closes #97 


One important note is that Color data isn't imported from rdm to gltf yet, but I honestly don't give a fuck about it. It's all about exporting my own custom cloths. I had to restructure the code to convert gltf iterators to AnnoData quite a bit, but that should make life easier for composing more vertex formats in the future. 


## Cloth Support

This implements the `P3f_N3f_G3f_B3f_T2f_C4b` vertex format for cloth meshes. 

## Decal Detail Support

This implements the `P4h_T2h_C4b` vertex format for decal details.