### PR TITLE
deps: upgrade gltf crate from 1.3.0 to 1.4.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+docs/AGENTS.md

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,9 +135,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "block-buffer"
@@ -159,6 +159,12 @@ name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
@@ -220,12 +226,6 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
-
-[[package]]
-name = "color_quant"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "colorchoice"
@@ -331,23 +331,24 @@ dependencies = [
 
 [[package]]
 name = "gltf"
-version = "1.3.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad2dcfb6dd7a66f9eb3d181a29dcfb22d146b0bcdc2e1ed1713cbf03939a88ea"
+checksum = "e3ce1918195723ce6ac74e80542c5a96a40c2b26162c1957a5cd70799b8cacf7"
 dependencies = [
  "base64",
  "byteorder",
  "gltf-json",
  "image",
  "lazy_static",
+ "serde_json",
  "urlencoding",
 ]
 
 [[package]]
 name = "gltf-derive"
-version = "1.3.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2cbcea5dd47e7ad4e9ee6f040384fcd7204bbf671aa4f9e7ca7dfc9bfa1de20"
+checksum = "14070e711538afba5d6c807edb74bcb84e5dbb9211a3bf5dea0dfab5b24f4c51"
 dependencies = [
  "inflections",
  "proc-macro2",
@@ -357,9 +358,9 @@ dependencies = [
 
 [[package]]
 name = "gltf-json"
-version = "1.3.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d5b810806b78dde4b71a95cc0e6fdcab34c4c617da3574df166f9987be97d03"
+checksum = "e6176f9d60a7eab0a877e8e96548605dedbde9190a7ae1e80bbcc1c9af03ab14"
 dependencies = [
  "gltf-derive",
  "serde",
@@ -381,16 +382,17 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "image"
-version = "0.24.9"
+version = "0.25.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5690139d2f55868e080017335e4b94cb7414274c74f1669c84fb5feba2c9f69d"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
 dependencies = [
  "bytemuck",
- "byteorder",
- "color_quant",
- "jpeg-decoder",
+ "byteorder-lite",
+ "moxcms",
  "num-traits",
  "png",
+ "zune-core",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -436,12 +438,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jpeg-decoder"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00810f1d8b74be64b13dbf3db89ac67740615d6c891f0e7b6179326533011a07"
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -483,6 +479,16 @@ checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
  "simd-adler32",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
 ]
 
 [[package]]
@@ -569,9 +575,9 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "png"
-version = "0.17.16"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
  "bitflags",
  "crc32fast",
@@ -603,6 +609,12 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "pxfm"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
 
 [[package]]
 name = "quick-xml"
@@ -865,3 +877,18 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -165,10 +165,9 @@ comments are sparse. When adding code, at minimum document public API items.
 
 ### Dependencies
 
-Two dependencies are pinned to exact versions (`binrw = "=0.11.2"`,
-`gltf = "=1.3.0"`) because the code relies on specific API details. Do not
-bump these without verifying compatibility. Key crates: `binrw`, `nalgebra`,
-`gltf`, `half`, `clap`, `quick-xml`.
+`binrw = "=0.11.2"` is pinned to an exact version because the code relies
+on specific API details. Do not bump it without verifying compatibility.
+Key crates: `binrw`, `nalgebra`, `gltf`, `half`, `clap`, `quick-xml`.
 
 ## Commit Messages
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -23,6 +23,9 @@ Dependency updates typically touch three `Cargo.toml` files:
 - `rdm4lib/Cargo.toml` (core conversion logic)
 - `cfghelper/Cargo.toml` (XML cfg parser)
 
+Note: `rdm4lib` is a **path dependency**, not a workspace member. The
+workspace members are `cfghelper` and `rdm_derive`.
+
 ## External Instructions
 
 - `AGENTS.md` references external files; load them with the Read tool when relevant.
@@ -168,6 +171,85 @@ comments are sparse. When adding code, at minimum document public API items.
 `binrw = "=0.11.2"` is pinned to an exact version because the code relies
 on specific API details. Do not bump it without verifying compatibility.
 Key crates: `binrw`, `nalgebra`, `gltf`, `half`, `clap`, `quick-xml`.
+
+## Architecture
+
+### Conversion Pipelines
+
+**RDM → glTF** (`src/main.rs` without `--gltf` flag):
+`RdModell::from(path)` → optional `add_skin()` / `add_anim()` →
+`gltf_export::build()` → GLB/glTF output
+
+**glTF → RDM** (`src/main.rs` with `--gltf FORMAT`):
+`ImportedGltf::try_import()` → `read_mesh()` / `read_skin()` /
+`read_animation()` → `RdWriter2::new(rdm).write_rdm()` → RDM binary
+
+### Core Types
+
+| Type                 | Module             | Role                                    |
+| -------------------- | ------------------ | --------------------------------------- |
+| `RdModell`           | `lib.rs`           | Central in-memory 3D model              |
+| `RdAnim`             | `rdm_anim.rs`      | Loaded animation data                   |
+| `RdJoint`            | `lib.rs`           | Skeleton bone (name, transform, parent) |
+| `VertexFormat2`      | `vertex.rs`        | Vertex layout descriptor + raw bytes    |
+| `TargetVertexFormat` | `vertex.rs`        | Enum of 6 supported output formats      |
+| `ImportedGltf`       | `gltf_reader.rs`   | Loaded glTF document + buffers          |
+| `RdWriter2`          | `rdm_data_main.rs` | Serializes `RdModell` to RDM binary     |
+| `RdAnimWriter2`      | `rdm_data_anim.rs` | Serializes `RdAnim` to RDM binary       |
+| `RdmFile<T>`         | `rdm_data_main.rs` | Binary RDM file wrapper (mesh or anim)  |
+
+Vertex components are const-generic types: `P4h` (position f16×4), `N4b`
+(normal u8×4), `G4b` (tangent), `B4b` (bitangent), `T2h` (texcoord f16×2),
+`I4b` (joint index), `W4b` (weight), `C4b` (color).
+
+### RdmStructSize Proc Macro
+
+`#[derive(RdmStructSize)]` generates `impl RDMStructSizeTr` by creating a
+shadow `#[repr(C, packed(1))]` struct where all `AnnoPtr<T>` fields are
+replaced with `u32`, then returning `size_of` of the packed struct. Must be
+paired with `#[binrw]` and `#[bw(import_raw(end: &mut u64))]`.
+
+### cfghelper (Deprecated)
+
+The `cfghelper` crate is **deprecated** and will be removed. Avoid adding
+new functionality to it.
+
+## Test Data
+
+- **RDM fixtures**: `rdm4lib/rdm/` — binary `.rdm` files (meshes and
+  animations) at various LOD levels
+- **glTF fixtures**: `rdm4lib/rdm/gltf/` — test glTF files
+  (`stormtrooper.gltf`, `triangle.gltf`)
+- **cfghelper fixtures**: `cfghelper/tests/cfgs/` — XML `.cfg` inputs and
+  `.cfgn` expected outputs
+
+Tests verify correctness via vertex count assertions, format string checks,
+and SHA-256 hash comparison (`check_hash()`). The `gltf_validator` CLI is
+invoked in integration tests and must be on PATH.
+
+## Platform-Specific Behavior
+
+- DDS texture conversion requires **Windows** + `texconv.exe`
+- Some tests are gated with `#[cfg(target_os = "linux")]` or
+  `#[cfg(target_os = "windows")]`
+- CI runs a **Linux + Windows matrix**; both download `gltf_validator`,
+  Windows also downloads `texconv.exe`
+
+## Gotchas
+
+- **No structured error handling**: the codebase uses `unwrap()` / `expect()`
+  pervasively (~130 calls). Errors surface as panics, not `Result` types.
+  There are no `anyhow` / `thiserror` dependencies.
+- **Template-based RDM writing**: `RdWriter2` uses an embedded template
+  (`basalt_crusher_others_lod0.rdm`) and patches specific sections. Changes
+  to the output format must account for this approach.
+- **Animation joint matching**: defaults to matching by unique name
+  (`ResolveNodeName::UniqueName`). Duplicate joint names require fallback
+  to `UnstableIndex`.
+- **`--no_transform` with animations**: omitting this flag when a skeleton
+  is present can cause severe mesh deformation (logged as a warning).
+- **Entire file loaded into memory**: no streaming; unsuitable for very
+  large models.
 
 ## Commit Messages
 

--- a/rdm4lib/Cargo.toml
+++ b/rdm4lib/Cargo.toml
@@ -24,7 +24,7 @@ version = "0.2.0"
 features = ["alloc"]
 
 [dependencies.gltf]
-version = "=1.3.0"
+version = "=1.4.1"
 features = ["extras", "names"]
 
 [dependencies.half]

--- a/rdm4lib/Cargo.toml
+++ b/rdm4lib/Cargo.toml
@@ -24,7 +24,7 @@ version = "0.2.0"
 features = ["alloc"]
 
 [dependencies.gltf]
-version = "=1.4.1"
+version = "1.4.1"
 features = ["extras", "names"]
 
 [dependencies.half]

--- a/rdm4lib/src/gltf_export.rs
+++ b/rdm4lib/src/gltf_export.rs
@@ -1,9 +1,9 @@
 use crate::{rdm_data_main::MeshInfo, rdm_material::RdMaterial, vertex::*, RdJoint, RdModell};
+use gltf::json::validation::USize64;
 use gltf::{json, json::validation::Checked::Valid, mesh::Semantic};
 use std::{
     borrow::Cow,
     collections::{BTreeMap, HashMap},
-    convert::TryInto,
     env,
     fs::{self, File, OpenOptions},
     io::{self, Read, Write},
@@ -166,8 +166,8 @@ impl RdGltfBuilder {
 
             let rot_buffer_view = json::buffer::View {
                 buffer: json::Index::new(buffv_idx),
-                byte_length: rot_real_len as u32,
-                byte_offset: Some(rot_start as u32),
+                byte_length: USize64(rot_real_len as u64),
+                byte_offset: Some(USize64(rot_start as u64)),
                 byte_stride: None,
                 extensions: Default::default(),
                 extras: Default::default(),
@@ -178,7 +178,7 @@ impl RdGltfBuilder {
             let rot_accessor = json::Accessor {
                 buffer_view: Some(json::Index::new(bv_idx)),
                 byte_offset: None,
-                count: count as u32,
+                count: USize64(count as u64),
                 component_type: Valid(json::accessor::GenericComponentType(
                     json::accessor::ComponentType::F32,
                 )),
@@ -198,8 +198,8 @@ impl RdGltfBuilder {
 
             let trans_buffer_view = json::buffer::View {
                 buffer: json::Index::new(buffv_idx),
-                byte_length: trans_real_len as u32,
-                byte_offset: Some((rot_size + trans_start) as u32),
+                byte_length: USize64(trans_real_len as u64),
+                byte_offset: Some(USize64((rot_size + trans_start) as u64)),
                 byte_stride: None,
                 extensions: Default::default(),
                 extras: Default::default(),
@@ -210,7 +210,7 @@ impl RdGltfBuilder {
             let trans_accessor = json::Accessor {
                 buffer_view: Some(json::Index::new(bv_idx)),
                 byte_offset: None,
-                count: count as u32,
+                count: USize64(count as u64),
                 component_type: Valid(json::accessor::GenericComponentType(
                     json::accessor::ComponentType::F32,
                 )),
@@ -230,8 +230,8 @@ impl RdGltfBuilder {
 
             let time_buffer_view = json::buffer::View {
                 buffer: json::Index::new(buffv_idx),
-                byte_length: t_real_len as u32,
-                byte_offset: Some((rot_size + trans_size + t_start) as u32),
+                byte_length: USize64(t_real_len as u64),
+                byte_offset: Some(USize64((rot_size + trans_size + t_start) as u64)),
                 byte_stride: None,
                 extensions: Default::default(),
                 extras: Default::default(),
@@ -242,7 +242,7 @@ impl RdGltfBuilder {
             let time_accessor = json::Accessor {
                 buffer_view: Some(json::Index::new(bv_idx)),
                 byte_offset: None,
-                count: count as u32,
+                count: USize64(count as u64),
                 component_type: Valid(json::accessor::GenericComponentType(
                     json::accessor::ComponentType::F32,
                 )),
@@ -334,7 +334,9 @@ impl RdGltfBuilder {
         assert_eq!(buffv_idx, buffer_result.idx);
 
         let anim_buffer = json::Buffer {
-            byte_length: (rot_anim_buf.len() + trans_anim_buf.len() + t_anim_buf.len()) as u32,
+            byte_length: USize64(
+                (rot_anim_buf.len() + trans_anim_buf.len() + t_anim_buf.len()) as u64,
+            ),
             extensions: Default::default(),
             extras: Default::default(),
             name: None,
@@ -766,7 +768,7 @@ impl RdGltfBuilder {
     ) -> u32 {
         let buffer_p = inner.push_buffer(buffer);
         let buffer = json::Buffer {
-            byte_length: buffer_p.len,
+            byte_length: USize64(buffer_p.len as u64),
             extensions: Default::default(),
             extras: Default::default(),
             name: None,
@@ -816,7 +818,7 @@ impl RdGltfBuilder {
         let normals_acc = json::Accessor {
             buffer_view: Some(json::Index::new(buffer_views_idx)),
             byte_offset: None,
-            count: count.unwrap_or(vattr_len),
+            count: USize64(count.unwrap_or(vattr_len) as u64),
             component_type: Valid(json::accessor::GenericComponentType(component_type)),
             extensions: Default::default(),
             extras: Default::default(),
@@ -1029,11 +1031,13 @@ impl RdGltfBuilder {
 
         for view in self.buffer_views.iter_mut() {
             let n = view_off_mapping[view.buffer.value()];
-            view.byte_offset = Some(view.byte_offset.unwrap_or(0) + n);
+            view.byte_offset = Some(USize64(
+                view.byte_offset.map(|x| x.0).unwrap_or(0) + n as u64,
+            ));
             view.buffer = json::Index::new(0);
         }
 
-        self.buffers[0].byte_length = combined_vec.len().try_into().unwrap();
+        self.buffers[0].byte_length = USize64(combined_vec.len() as u64);
         let padded_combined_vec = BufferContainer::U8(combined_vec);
         debug!(
             "size_merge_buffer: {:#?}",


### PR DESCRIPTION
Migrate offset/size fields from u32 to USize64 in gltf_export.rs to match the gltf-json 1.4.0 API change. Output is byte-identical.